### PR TITLE
Bringing over Fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Version - 0.0.41b - [5b0aed8](https://github.com/k8thekat/AMPAPI_Python/commit/5b0aed8)
+#### __init__.py
+- Version bump `0.0.41b
+
+#### types.py
+- Added `LastExecuteError` and `LastErrorReason` to `Triggers()` dataclass.
+
+#### base.py
+- Removed un-used code.
+
+#### Changelog.md
+- Version log - `0.0.40b`
+
 ## Version - 0.0.40b - [b055fb3](https://github.com/k8thekat/AMPAPI_Python/commit/b055fb3)
 #### Readme.md
 - Changed TestPypi to Pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Version - 0.0.40b - [b055fb3](https://github.com/k8thekat/AMPAPI_Python/commit/b055fb3)
+#### Readme.md
+- Changed TestPypi to Pypi
+	- Updated bash commands for installing package.
+
+#### init.py
+- Version bump `0.0.40b`
+
+#### Overall
+- `isort` imports
+
 ## Version - 0.0.39b - [778bb87](https://github.com/k8thekat/AMPAPI_Python/commit/778bb87)
 #### __init__.py
 - Version bump `0.0.39b`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ async def Sample_API():
     _bridge = Bridge(api_params=_params)
     ADS: ADSInstance = ADSInstance()
     # This would populate the ADS class property .AvailableInstances
-    ADS.get_instances()
+    await ADS.get_instances()
     # We can break out all our instances into their own attributes.
     arkinstance: AMPInstance | AMPMinecraftInstance = ADS.AvailableInstances[1]
     mcinstance: AMPInstance | AMPMinecraftInstance = ADS.AvailableInstances[2]

--- a/ampapi/__init__.py
+++ b/ampapi/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 __title__ = "CubeCoders AMP API"
 __author__ = "k8thekat"
 __license__ = "GNU"
-__version__ = "0.0.41b"
+__version__ = "0.0.42b"
 __credits__ = "AMP by CubeCoders and associates."
 
 from typing import Literal, NamedTuple

--- a/ampapi/__init__.py
+++ b/ampapi/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 __title__ = "CubeCoders AMP API"
 __author__ = "k8thekat"
 __license__ = "GNU"
-__version__ = "0.0.40b"
+__version__ = "0.0.41b"
 __credits__ = "AMP by CubeCoders and associates."
 
 from typing import Literal, NamedTuple

--- a/ampapi/ads.py
+++ b/ampapi/ads.py
@@ -37,8 +37,8 @@ class ADSInstance(ADSModule, Core, EmailSenderPlugin, LocalFileBackupPlugin, Fil
                 else:
                     self._AvailableInstances.append(AMPInstance(data=instances[i]))
 
-    def __init__(self):
-        # print(f"DEBUG {type(self).__name__} __init__")
+    def __init__(self) -> None:
+        self._logger.debug(msg=f"DEBUG {type(self).__name__} __init__")
         super().__init__()
 
     async def get_instances(self, format_data: Union[bool, None] = None) -> list[Controller | Self]:
@@ -54,9 +54,9 @@ class ADSInstance(ADSModule, Core, EmailSenderPlugin, LocalFileBackupPlugin, Fil
 
         """
 
-        ads_list = []
+        ads_list: list[ADSInstance | Controller] = []
         result: list[Controller] = await super().get_instances(format_data=format_data)
-        if isinstance(result, list):
+        if isinstance(result, list) and isinstance(result[0], Controller):
             self.parse_data(data=result[0])  # Need to update our self object.
             for i in range(1, len(result)):
                 ads_list.append(ADSInstance().parse_data(data=result[i]))

--- a/ampapi/base.py
+++ b/ampapi/base.py
@@ -52,7 +52,7 @@ class Base():
             raise ValueError(self.NO_BRIDGE)
 
         if isinstance(bridge, Bridge):
-            self.parse_bridge(bridge=bridge)  # type:ignore
+            self.parse_bridge(bridge=bridge)
 
     @property
     def format_data(self) -> bool:
@@ -68,7 +68,7 @@ class Base():
         return FORMAT_DATA
 
     @format_data.setter
-    def format_data(self, value: bool):
+    def format_data(self, value: bool) -> None:
         global FORMAT_DATA
         FORMAT_DATA = value
 
@@ -278,11 +278,11 @@ class Base():
                 self._logger.error(f"{api} failed because of Status: {post_req_json}")
                 return ConnectionError(self.FAILED_API)
 
-        # print("DEBUG", "FORMAT->", format_data, format)
-        if format is None or format_data is False:
+        self._logger.debug(msg=f"DEBUG _call_api | format_data = {format_data} | FORMAT_DATA = {FORMAT_DATA} | FORMAT-> {format}")
+        if (format is None or format_data is False) or (format_data is None and FORMAT_DATA is False):
             return post_req_json
 
-        elif format_data is True or format_data is None and FORMAT_DATA is True:
+        elif (format_data is True) or (format_data is None and FORMAT_DATA is True):
             return self.json_to_dataclass(json=post_req_json, format=format, _use_from_dict=_use_from_dict, _auto_unpack=_auto_unpack)
 
     async def _connect(self) -> LoginResults | None:

--- a/ampapi/base.py
+++ b/ampapi/base.py
@@ -37,20 +37,17 @@ class Base():
     session_ttl: int = 240
     url: str = ""
 
-    # self.FAILED_LOGIN: str = ""
     NO_DATA: str = "Failed to receive any data from post request."
     ADS_ONLY: str = "This API call is only available on ADS instances."
     UNAUTHORIZED_ACCESS: str = "The user does not have the required permissions to interact with this instance."
     NO_BRIDGE: str = "Failed to setup connection. You need to initiate `<class Bridge>` first."
     MINECRAFT_ONLY: str = "This API call is only available on Minecraft instances."
     FAILED_API: str = "The API call returned a non-proper response."
-    # NO_VALID_SESSION: str = "Failed to find a valid session id, please login again."
 
     def __init__(self) -> None:
         bridge: Bridge = Bridge.get_bridge()
         # Validate the bridge object is at the same memory address.
         self._logger.debug(f"bridge object -> {bridge}")
-        # print("DEBUG", f"bridge object -> {bridge}")
         if bridge == None:
             raise ValueError(self.NO_BRIDGE)
 

--- a/ampapi/bridge.py
+++ b/ampapi/bridge.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import fields
 from typing import TYPE_CHECKING, Self
 
@@ -11,11 +12,12 @@ class Bridge(APIParams):
     Handles the API login credentials for connecting to AMP.
 
     Simply create the class similar to the example and then access any other API class you wish.\n
-        *eg* `_bridge: Bridge | None = Bridge(apiparams= <class APIparams>)`
+        *eg* `_bridge: Bridge | None = Bridge(ap_params= <class APIparams>)`
                 `APICore = Core() #this will pull login details from the Bridge class`
 
     """
-    apiparams: APIParams
+    api_params: APIParams
+    _logger: logging.Logger = logging.getLogger()
 
     @classmethod
     def get_bridge(cls) -> Self:
@@ -35,12 +37,12 @@ class Bridge(APIParams):
 
     def __new__(cls, api_params: APIParams | None = None, *args, **kwargs) -> Self | None:
         if not hasattr(cls, "_instance"):
-            cls._instance = super(Bridge, cls).__new__(cls, *args, **kwargs)
+            cls._instance: Self = super(Bridge, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self, api_params: APIParams, *args, **kwargs) -> None:
-        # print("DEBUG Bridge __init__")
+        self._logger.debug(msg="DEBUG Bridge __init__")
         self.api_params: APIParams = api_params
         # We parse the api params for easier usage.
-        for field in fields(api_params):
+        for field in fields(class_or_instance=api_params):
             setattr(self, field.name, getattr(self.api_params, field.name))

--- a/ampapi/minecraft.py
+++ b/ampapi/minecraft.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Union
 
-from dataclass_wizard import fromdict
-
 from .base import FORMAT_DATA, Base
 from .types import *
 

--- a/ampapi/types.py
+++ b/ampapi/types.py
@@ -376,7 +376,7 @@ class Instance():
     Description: str = ""
 
 
-@dataclass()
+@dataclass(repr=False)
 class Controller():
     """
     Represents an AMP Controller (aka Target manager) that manages the Instances it has access to.

--- a/ampapi/types.py
+++ b/ampapi/types.py
@@ -466,6 +466,8 @@ class Triggers():
     Description: str = ""
     TriggerType: str = ""
     Emits: list[str] = field(default_factory=list[str])
+    LastExecuteError: bool = field(default=False)
+    LastErrorReason: str = field(default="")
 
 
 @dataclass()


### PR DESCRIPTION
## Version - 0.0.42b - [2bf7996](https://github.com/k8thekat/AMPAPI_Python/commit/2bf7996)
#### Changelog.md
- Version info from `0.0.41b`

#### __init__.py
- Version bump `0.0.42b`

#### README.md
- Added missing `await` in Quick Example - Sample_API().

#### ads.py
- Changed some prints to `_logger.debug()`.
- Type-hinted `ads_list` inside `get_instances()` method.
- Added logic check to `get_instances()` when not formatting data to prevent error.

#### base.py
- Removed `type:ignore` from `__init__()`.
- Added return value to `format_data` setter.
- Added `_logger.debug()` for monitoring data formatting.
- Fixed logic when formatting data causing return failure using the `ADSInstance` class.
- Improved readability of format logic of `_call_api()`.

#### bridge.py
- Added logging.
- Changed `apiparams` to `api_params`.
- Added type-hinting to `__new__()`.
- Added `_logger.debug()` to `__init__()`.

#### minecraft.py
- Removed unused imports.

#### types.py
- added `repr = False` to the `Controller()` dataclass.
