### PR TITLE
Initialise self.sorted

### DIFF
--- a/ampapi/dataclass.py
+++ b/ampapi/dataclass.py
@@ -1838,6 +1838,7 @@ class Players:
     sorted: list[Player]
 
     def __init__(self, data: dict[str, str]) -> None:
+        self.sorted = []
         for uuid, name in data.items():
             self.sorted.append(Player(uuid=uuid, name=name))
         self.sorted.sort(key=attrgetter("name"))


### PR DESCRIPTION
Hi, I was getting this error:

```
  File "/workspaces/ha-core/homeassistant/components/cubecoders/api.py", line 100, in async_get_data
    players = await instance_data.get_user_list()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/ampapi/core.py", line 1487, in get_user_list
    result: Any = await self._call_api(
                  ^^^^^^^^^^^^^^^^^^^^^
        api="Core/GetUserList", format_data=format_data, format_=Players, _use_from_dict=False, _auto_unpack=False
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/ampapi/base.py", line 303, in _call_api
    return self.json_to_dataclass(
           ~~~~~~~~~~~~~~~~~~~~~~^
        json=post_req_json, format_=format_, _use_from_dict=_use_from_dict, _auto_unpack=_auto_unpack
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/ampapi/base.py", line 537, in json_to_dataclass
    return format_(json)  # type: ignore
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/ampapi/dataclass.py", line 1843, in __init__
    self.sorted.sort(key=attrgetter("name"))
    ^^^^^^^^^^^
```

Looks like sorted hasn't been initialised, this change fixed it. Given the class has `init=False` the list is never initialised automatically by dataclasses